### PR TITLE
Recommendation Engine Edits 

### DIFF
--- a/app/controllers/api/v1/recommendations_controller.rb
+++ b/app/controllers/api/v1/recommendations_controller.rb
@@ -32,7 +32,7 @@ class Api::V1::RecommendationsController < ApplicationController
         poster_url: TmdbService.full_poster_url(tmdb_data["poster_path"]),
         description: tmdb_data["overview"]
       )
-    end
+    end 
 
     # Step 4: Create a Recommendation record
     Recommendation.create!(

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -9,4 +9,12 @@ class Recommendation < ApplicationRecord
   validates :recommended_at, presence: true
   validates :openai_prompt, presence: true
   validates :openai_response, presence: true
+
+  before_validation :set_recommended_title
+
+  private
+  
+  def set_recommended_title
+    self.recommended_title = movie.title if movie.present?
+  end
 end

--- a/db/migrate/20250730221601_add_movie_title_to_recommendations.rb
+++ b/db/migrate/20250730221601_add_movie_title_to_recommendations.rb
@@ -1,0 +1,5 @@
+class AddMovieTitleToRecommendations < ActiveRecord::Migration[7.1]
+  def change
+    add_column :recommendations, :movie_title, :string
+  end
+end

--- a/db/migrate/20250730223207_rename_movie_title_to_recommended_title_in_recommendations.rb
+++ b/db/migrate/20250730223207_rename_movie_title_to_recommended_title_in_recommendations.rb
@@ -1,0 +1,5 @@
+class RenameMovieTitleToRecommendedTitleInRecommendations < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :recommendations, :movie_title, :recommended_title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_30_221601) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_30_223207) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,7 +63,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_30_221601) do
     t.text "openai_response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "movie_title"
+    t.string "recommended_title"
     t.index ["movie_id"], name: "index_recommendations_on_movie_id"
     t.index ["user_id"], name: "index_recommendations_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_07_19_023808) do
+ActiveRecord::Schema[7.1].define(version: 2025_07_30_221601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,32 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_19_023808) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "description"
+  end
+
+  create_table "offers", force: :cascade do |t|
+    t.bigint "movie_id", null: false
+    t.bigint "provider_id", null: false
+    t.string "offer_type", null: false
+    t.decimal "price", precision: 8, scale: 2
+    t.string "url"
+    t.boolean "available", default: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["available"], name: "index_offers_on_available"
+    t.index ["movie_id", "provider_id", "offer_type"], name: "index_offers_on_movie_provider_type", unique: true
+    t.index ["movie_id"], name: "index_offers_on_movie_id"
+    t.index ["offer_type"], name: "index_offers_on_offer_type"
+    t.index ["provider_id"], name: "index_offers_on_provider_id"
+  end
+
+  create_table "providers", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "justwatch_id", null: false
+    t.string "logo_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["justwatch_id"], name: "index_providers_on_justwatch_id", unique: true
+    t.index ["name"], name: "index_providers_on_name"
   end
 
   create_table "recommendations", force: :cascade do |t|
@@ -37,6 +63,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_19_023808) do
     t.text "openai_response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "movie_title"
     t.index ["movie_id"], name: "index_recommendations_on_movie_id"
     t.index ["user_id"], name: "index_recommendations_on_user_id"
   end
@@ -51,6 +78,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_19_023808) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "offers", "movies"
+  add_foreign_key "offers", "providers"
   add_foreign_key "recommendations", "movies"
   add_foreign_key "recommendations", "users"
 end

--- a/spec/models/recommendation_spec.rb
+++ b/spec/models/recommendation_spec.rb
@@ -15,4 +15,31 @@ RSpec.describe Recommendation, type: :model do
     it { should validate_presence_of(:openai_prompt) }
     it { should validate_presence_of(:openai_response) }
   end
+
+  describe 'callbacks' do
+    it 'sets recommended_title from associated movie before validation' do
+      movie = Movie.create!(title: "No Country for Old Men", tmdb_id: 12345)
+        user = User.create!(
+          username: 'testuser',
+          email: 'test@example.com',
+          password: 'ParisTexas123',
+          password_confirmation: 'ParisTexas123'
+        )
+
+      recommendation = Recommendation.create!(
+        user: user,
+        movie: movie,
+        tmdb_id: movie.tmdb_id,
+        mood: "moody",
+        genre: "drama",
+        decade: "2000s",
+        runtime: "2h",
+        recommended_at: Time.current,
+        openai_prompt: "Some prompt",
+        openai_response: "Some response"
+      )
+
+      expect(recommendation.recommended_title).to eq("No Country for Old Men")
+    end
+  end
 end


### PR DESCRIPTION
###  Add `recommended_title` to Recommendations

- Added `recommended_title` column to `recommendations` table via migration  
- Added `before_validation` callback in `Recommendation` model to set `recommended_title` from associated `movie.title`  
- Added model spec to test that `recommended_title` is correctly set on creation

This improves dev visibility by surfacing movie titles directly in recommendation records. No more cross referencing tables!