### PR TITLE
Multiple Recommendations Batch/Engine && Refactoring w/ Tests

### DIFF
--- a/app/controllers/api/v1/recommendations_controller.rb
+++ b/app/controllers/api/v1/recommendations_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::RecommendationsController < ApplicationController
+  before_action :authenticate_user!
+  
   def create
     # 1) Accept parameters
     mood    = params[:mood]

--- a/app/controllers/api/v1/recommendations_controller.rb
+++ b/app/controllers/api/v1/recommendations_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::RecommendationsController < ApplicationController
   before_action :authenticate_user!
-  
+
   def create
     # 1) Accept parameters
     mood    = params[:mood]
@@ -52,6 +52,9 @@ class Api::V1::RecommendationsController < ApplicationController
       m.poster_url = primary[:poster_url]
       m.description = primary[:description]
     end
+
+    # 👇 Add this so the first choice includes a DB id the FE can save
+    enriched.first[:movie_id] = movie.id
 
     recommendation = Recommendation.new(
       user: current_user,

--- a/app/controllers/api/v1/recommendations_controller.rb
+++ b/app/controllers/api/v1/recommendations_controller.rb
@@ -1,40 +1,56 @@
 class Api::V1::RecommendationsController < ApplicationController
-  before_action :authenticate_user!
-
   def create
-    # Step 1: Accept parameters
+    # 1) Accept parameters
     mood    = params[:mood]
     genre   = params[:genre]
     decade  = params[:decade]
-    runtime_filter = params[:runtime_filter] || params[:runtime]
-    runtime = runtime_filter
+    runtime = params[:runtime_filter] || params[:runtime]
 
-    # Step 2: Call OpenAIService
-    ai_result = OpenAiService.recommend_movie(mood: mood, genre: genre, decade: decade, runtime_filter: runtime_filter)
-    movie_title = ai_result[:title].gsub(/\A"|"\Z/, '').strip
-    full_response = ai_result[:full_response]
+    # 2) Call OpenAI for THREE candidates (title + release_year)
+    ai = OpenAiService.recommend_movies(
+      mood: mood,
+      genre: genre,
+      decade: decade,
+      runtime_filter: runtime
+    )
+    return render json: { error: "OpenAI request failed" }, status: :bad_gateway if ai.nil?
 
-    # Step 3: Check if movie exists in DB, otherwise fetch from TMDB
-    movie = Movie.find_by(title: movie_title)
+    candidates = ai[:items]
+    if candidates.blank?
+      return render json: { error: "No candidates returned" }, status: :bad_gateway
+    end
 
-    if movie.nil?
-      tmdb_data = TmdbService.search_movie(movie_title)
+    # 3) Enrich each candidate via TMDB (query + year)
+    enriched = candidates.map do |cand|
+      next if cand[:title].blank? || cand[:release_year].to_i <= 0
 
-      if tmdb_data.nil?
-        render json: { error: "Movie not found" }, status: :not_found and return
-      end
+      hit = TmdbService.search_movie_with_year(cand[:title], cand[:release_year])
+      next unless hit
 
-      details = TmdbService.movie_details(tmdb_data["id"])
+      details = TmdbService.movie_details(hit["id"])
+      {
+        title: hit["title"],
+        release_year: cand[:release_year],
+        tmdb_id: hit["id"],
+        poster_url: TmdbService.full_poster_url(hit["poster_path"]),
+        description: hit["overview"],
+        runtime_minutes: details&.dig("runtime")
+      }
+    end.compact
 
-    movie = Movie.find_or_create_by!(tmdb_id: tmdb_data["id"]) do |m|
-        m.title = tmdb_data["title"]
-        m.runtime = details["runtime"]
-        m.poster_url = TmdbService.full_poster_url(tmdb_data["poster_path"])
-        m.description = tmdb_data["overview"]
-      end
-    end 
+    if enriched.blank?
+      return render json: { error: "No matching movies found" }, status: :not_found
+    end
 
-    # Step 4: Create a Recommendation record
+    # 4) Persist ONLY the first enriched item (MVP)
+    primary = enriched.first
+    movie = Movie.find_or_create_by!(tmdb_id: primary[:tmdb_id]) do |m|
+      m.title = primary[:title]
+      m.runtime = primary[:runtime_minutes]
+      m.poster_url = primary[:poster_url]
+      m.description = primary[:description]
+    end
+
     recommendation = Recommendation.new(
       user: current_user,
       movie: movie,
@@ -44,8 +60,8 @@ class Api::V1::RecommendationsController < ApplicationController
       decade: decade,
       runtime: runtime,
       recommended_at: Time.current,
-      openai_prompt: OpenAiService.generate_prompt(mood: mood, genre: genre, decade: decade, runtime_filter: runtime),
-      openai_response: full_response
+      openai_prompt: OpenAiService.generate_prompt_multi(mood: mood, genre: genre, decade: decade, runtime_filter: runtime),
+      openai_response: ai[:full_response]
     )
 
     unless recommendation.save
@@ -53,7 +69,16 @@ class Api::V1::RecommendationsController < ApplicationController
       return render json: { error: "Recommendation could not be created", details: recommendation.errors.full_messages }, status: :unprocessable_entity
     end
 
-    # Step 5: Return the serialized movie
-    render json: RecommendationSerializer.new(recommendation), status: :ok
+    # 5) Return the batch so FE can step through by index
+    render json: {
+      data: {
+        type: "recommendation_batch",
+        id: recommendation.id.to_s,
+        attributes: {
+          primary_recommendation_id: recommendation.id,
+          choices: enriched
+        }
+      }
+    }, status: :ok
   end
 end

--- a/app/controllers/api/v1/saved_movies_controller.rb
+++ b/app/controllers/api/v1/saved_movies_controller.rb
@@ -9,12 +9,17 @@ class Api::V1::SavedMoviesController < ApplicationController
   end
 
   def create
-    movie = Movie.find_by(id: params[:saved_movie][:movie_id])
-    return render json: { error: "Movie not found" }, status: :not_found unless movie
+    # @movie is set in set_movie
+    return render json: { error: "Movie not found" }, status: :not_found unless @movie
+
+    # If it already exists for this user, return it (idempotent save)
+    if (existing = current_user.saved_movies.find_by(movie_id: @movie.id))
+      return render json: SavedMovieSerializer.new(existing).serializable_hash, status: :ok
+    end
 
     saved_movie = current_user.saved_movies.create(
-      movie: movie,
-      title: movie.title
+      movie: @movie,
+      title: @movie.title
     )
 
     if saved_movie.persisted?
@@ -29,27 +34,50 @@ class Api::V1::SavedMoviesController < ApplicationController
     head :no_content
   end
 
-
   private
 
   def set_movie
-    puts "🔍 Raw params: #{params.inspect}"
-    puts "✅ Permitted saved_movie_params: #{saved_movie_params.inspect}"
+    Rails.logger.debug { "🔍 Raw params: #{params.inspect}" }
+    Rails.logger.debug { "✅ Permitted saved_movie_params: #{saved_movie_params.inspect}" }
 
-    @movie = Movie.find_by(id: saved_movie_params[:movie_id])
-    unless @movie
-      render json: { error: "Movie not found" }, status: :not_found
+    # 1) Prefer explicit movie_id
+    if saved_movie_params[:movie_id].present?
+      @movie = Movie.find_by(id: saved_movie_params[:movie_id])
+      return if @movie
+      render(json: { error: "Movie not found" }, status: :not_found) and return
     end
+
+    # 2) Fallback: accept tmdb_id and hydrate from TMDB if needed
+    if saved_movie_params[:tmdb_id].present?
+      tmdb_id = saved_movie_params[:tmdb_id].to_i
+      @movie = Movie.find_by(tmdb_id: tmdb_id)
+      return if @movie
+
+      # Fetch details and create
+      details = TmdbService.movie_details(tmdb_id)
+      unless details
+        render(json: { error: "Movie not found" }, status: :not_found) and return
+      end
+
+      @movie = Movie.find_or_create_by!(tmdb_id: tmdb_id) do |m|
+        m.title       = details["title"] || details["name"]
+        m.runtime     = details["runtime"]
+        m.poster_url  = TmdbService.full_poster_url(details["poster_path"])
+        m.description = details["overview"]
+      end
+      return
+    end
+
+    # 3) Neither movie_id nor tmdb_id provided
+    render json: { error: "movie_id or tmdb_id is required" }, status: :bad_request
   end
 
   def set_saved_movie
     @saved_movie = current_user.saved_movies.find_by(id: params[:id])
-    unless @saved_movie
-      render json: { error: "Saved movie not found" }, status: :not_found
-    end
+    render(json: { error: "Saved movie not found" }, status: :not_found) unless @saved_movie
   end
 
   def saved_movie_params
-    params.require(:saved_movie).permit(:movie_id)
+    params.require(:saved_movie).permit(:movie_id, :tmdb_id)
   end
 end

--- a/app/controllers/api/v1/saved_movies_controller.rb
+++ b/app/controllers/api/v1/saved_movies_controller.rb
@@ -37,8 +37,6 @@ class Api::V1::SavedMoviesController < ApplicationController
   private
 
   def set_movie
-    Rails.logger.debug { "🔍 Raw params: #{params.inspect}" }
-    Rails.logger.debug { "✅ Permitted saved_movie_params: #{saved_movie_params.inspect}" }
 
     # 1) Prefer explicit movie_id
     if saved_movie_params[:movie_id].present?
@@ -78,6 +76,7 @@ class Api::V1::SavedMoviesController < ApplicationController
   end
 
   def saved_movie_params
-    params.require(:saved_movie).permit(:movie_id, :tmdb_id)
+    # If :saved_movie is missing, return an empty ActionController::Parameters
+    params.fetch(:saved_movie, {}).permit(:movie_id, :tmdb_id)
   end
 end

--- a/app/services/open_ai_service.rb
+++ b/app/services/open_ai_service.rb
@@ -46,6 +46,82 @@ class OpenAiService
     Return only the exact, full movie title as it appears in The Movie Database (TMDB).
     Do not include quotation marks, punctuation, or extra commentary.
     Use the correct capitalization and subtitle if applicable.
-  """.strip
+    """.strip
+  end
+
+  # Method to return an array of 3 recommendations at once
+  
+  def self.recommend_movies(mood:, genre:, decade:, runtime_filter:)
+    prompt = generate_prompt_multi(mood: mood, genre: genre, decade: decade, runtime_filter: runtime_filter)
+
+    response = post(
+      "/chat/completions",
+      headers: {
+        "Authorization" => "Bearer #{ENV['OPENAI_API_KEY']}",
+        "Content-Type" => "application/json"
+      },
+      body: {
+        model: "gpt-4o",
+        messages: [
+          { role: "system", content: "You are a movie expert who recommends films based on mood and context." },
+          { role: "user", content: prompt }
+        ],
+        temperature: 0.7
+      }.to_json
+    )
+
+    return nil unless response.success?
+
+    result  = response.parsed_response
+    content = result.dig("choices", 0, "message", "content").to_s
+
+    items = begin
+      parsed = JSON.parse(content)
+      parsed.is_a?(Array) ? parsed : []
+    rescue JSON::ParserError
+      []
+    end
+
+    # Normalize to array of up to 3 hashes { title:, release_year: }
+    normalized = items.first(3).map do |h|
+      if h.is_a?(Hash)
+        {
+          title: h["title"].to_s.strip,
+          release_year: h["release_year"].to_i
+        }
+      else
+        # Fallback if model ignored JSON (e.g., "Movie (1999)")
+        m = h.to_s.match(/(.+)\s+\((\d{4})\)/)
+        next unless m
+        { title: m[1].strip, release_year: m[2].to_i }
+      end
+    end.compact
+
+    {
+      items: normalized,       # [{ title:, release_year: }, ... up to 3]
+      prompt: prompt,
+      full_response: result
+    }
+  end
+
+  def self.generate_prompt_multi(mood:, genre:, decade:, runtime_filter:)
+    <<~TXT.strip
+      You are selecting movies that match:
+      - mood: "#{mood}"
+      - genre: "#{genre}"
+      - decade: "#{decade}"
+      - runtime preference: "#{runtime_filter}"
+
+      Return EXACTLY 3 REAL films that best fit.
+      Respond ONLY with strict JSON (no prose, no markdown), as an array of objects:
+
+      [
+        { "title": "Exact TMDB title", "release_year": 1999 },
+        { "title": "Exact TMDB title", "release_year": 2010 },
+        { "title": "Exact TMDB title", "release_year": 1975 }
+      ]
+
+      No trailing commas. Use the original theatrical release year.
+    TXT
   end
 end

--- a/app/services/open_ai_service.rb
+++ b/app/services/open_ai_service.rb
@@ -54,54 +54,68 @@ class OpenAiService
   def self.recommend_movies(mood:, genre:, decade:, runtime_filter:)
     prompt = generate_prompt_multi(mood: mood, genre: genre, decade: decade, runtime_filter: runtime_filter)
 
-    response = post(
-      "/chat/completions",
-      headers: {
-        "Authorization" => "Bearer #{ENV['OPENAI_API_KEY']}",
-        "Content-Type" => "application/json"
-      },
-      body: {
-        model: "gpt-4o",
-        messages: [
-          { role: "system", content: "You are a movie expert who recommends films based on mood and context." },
-          { role: "user", content: prompt }
-        ],
-        temperature: 0.7
-      }.to_json
-    )
+    begin
+      response = post(
+        "/chat/completions",
+        headers: {
+          "Authorization" => "Bearer #{ENV['OPENAI_API_KEY']}",
+          "Content-Type"  => "application/json"
+        },
+        body: {
+          model: "gpt-4o",
+          messages: [
+            { role: "system", content: "You are a movie expert who recommends films based on mood and context." },
+            { role: "user", content: prompt }
+          ],
+          temperature: 0.7
+        }.to_json,
+        timeout: 20
+      )
+    rescue SocketError, Net::ReadTimeout, HTTParty::Error => e
+      Rails.logger.error("[OpenAI] network error: #{e.class} #{e.message}")
+      return nil
+    end
 
-    return nil unless response.success?
+    unless response.success?
+      Rails.logger.error("[OpenAI] HTTP #{response.code} body: #{response.body.to_s[0,500]}")
+      return nil
+    end
 
     result  = response.parsed_response
     content = result.dig("choices", 0, "message", "content").to_s
+    Rails.logger.info("[OpenAI] content preview: #{content[0,200].gsub("\n"," ")}")
 
-    items = begin
-      parsed = JSON.parse(content)
-      parsed.is_a?(Array) ? parsed : []
-    rescue JSON::ParserError
-      []
+    # --- sanitize code fences / markdown wrappers ---
+    sanitized = content.strip
+    # remove ```json / ``` fence wrappers
+    sanitized = sanitized.gsub(/\A```(?:json)?\s*/i, '').gsub(/```+\s*\z/, '').strip
+    # if still not starting with [ or {, try to extract first JSON-ish block
+    unless sanitized.lstrip.start_with?('[', '{')
+      if (m = sanitized.match(/(\[[\s\S]*\]|\{[\s\S]*\})/m))
+        sanitized = m[1]
+      end
     end
+    Rails.logger.info("[OpenAI] content preview (sanitized): #{sanitized[0,200].gsub("\n"," ")}")
 
-    # Normalize to array of up to 3 hashes { title:, release_year: }
+    items =
+      begin
+        parsed = JSON.parse(sanitized)
+        parsed.is_a?(Array) ? parsed : (parsed["items"] || [])
+      rescue JSON::ParserError => e
+        Rails.logger.error("[OpenAI] JSON parse error after sanitize: #{e.message} content: #{sanitized[0,200]}")
+        []
+      end
+
     normalized = items.first(3).map do |h|
       if h.is_a?(Hash)
-        {
-          title: h["title"].to_s.strip,
-          release_year: h["release_year"].to_i
-        }
+        { title: h["title"].to_s.strip, release_year: h["release_year"].to_i }
       else
-        # Fallback if model ignored JSON (e.g., "Movie (1999)")
         m = h.to_s.match(/(.+)\s+\((\d{4})\)/)
-        next unless m
-        { title: m[1].strip, release_year: m[2].to_i }
+        m ? { title: m[1].strip, release_year: m[2].to_i } : nil
       end
     end.compact
 
-    {
-      items: normalized,       # [{ title:, release_year: }, ... up to 3]
-      prompt: prompt,
-      full_response: result
-    }
+    { items: normalized, prompt: prompt, full_response: result }
   end
 
   def self.generate_prompt_multi(mood:, genre:, decade:, runtime_filter:)
@@ -112,9 +126,8 @@ class OpenAiService
       - decade: "#{decade}"
       - runtime preference: "#{runtime_filter}"
 
-      Return EXACTLY 3 REAL films that best fit.
-      Respond ONLY with strict JSON (no prose, no markdown), as an array of objects:
-
+      Return EXACTLY 3 items and respond ONLY with raw JSON (no prose, no markdown, no code fences).
+      The response must be a JSON array of objects like:
       [
         { "title": "Exact TMDB title", "release_year": 1999 },
         { "title": "Exact TMDB title", "release_year": 2010 },

--- a/app/services/tmdb_service.rb
+++ b/app/services/tmdb_service.rb
@@ -27,6 +27,19 @@ class TmdbService
   end
 
   def self.full_poster_url(path)
+    return nil if path.nil? || path.empty?
     "https://image.tmdb.org/t/p/w500#{path}"
+  end
+
+  def self.search_movie_with_year(title, year)
+    response = self.get("/search/movie", query: {
+      query: title,
+      year: year,                # narrow to original release year
+      include_adult: false,
+      api_key: ENV["TMDB_API_KEY"]
+    })
+
+    return nil unless response.success? && response["results"].present?
+    response["results"].first
   end
 end

--- a/spec/requests/api/v1/saved_movies_request_spec.rb
+++ b/spec/requests/api/v1/saved_movies_request_spec.rb
@@ -46,4 +46,92 @@ RSpec.describe "Api::V1::SavedMovies", type: :request do
       expect(SavedMovie.exists?(saved_movie.id)).to be_falsey
     end
   end
+
+  describe "POST /api/v1/saved_movies (tmdb + edge cases)" do
+    let(:tmdb_id) { 4455 }
+
+    it "creates via tmdb_id when the Movie does not exist (hydrates from TMDB)" do
+      # stub TMDB lookups
+      details = {
+        "title" => "Coherence",
+        "runtime" => 89,
+        "poster_path" => "/coherence.jpg",
+        "overview" => "Dinner party multiverse."
+      }
+      allow(TmdbService).to receive(:movie_details).with(tmdb_id).and_return(details)
+      allow(TmdbService).to receive(:full_poster_url).with("/coherence.jpg")
+        .and_return("https://image.tmdb.org/t/p/w500/coherence.jpg")
+
+      expect {
+        post "/api/v1/saved_movies",
+          params: { saved_movie: { tmdb_id: tmdb_id } },
+          headers: headers
+      }.to change(Movie, :count).by(1).and change(SavedMovie, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+      expect(body.dig("data", "attributes", "title")).to eq("Coherence")
+    end
+
+    it "reuses existing Movie when posting tmdb_id for a movie already in DB" do
+      existing = create(:movie, tmdb_id: tmdb_id, title: "Coherence")
+      # Should not hit TMDB at all
+      expect(TmdbService).not_to receive(:movie_details)
+
+      expect {
+        post "/api/v1/saved_movies",
+          params: { saved_movie: { tmdb_id: tmdb_id } },
+          headers: headers
+      }.to change(Movie, :count).by(0).and change(SavedMovie, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(SavedMovie.last.movie_id).to eq(existing.id)
+    end
+
+    it "is idempotent: posting the same movie twice returns 200 and does not duplicate" do
+      # first save by movie_id
+      post "/api/v1/saved_movies",
+        params: { saved_movie: { movie_id: movie.id } },
+        headers: headers
+      expect(response).to have_http_status(:created)
+
+      # second save should return 200 OK and not create another row
+      expect {
+        post "/api/v1/saved_movies",
+          params: { saved_movie: { movie_id: movie.id } },
+          headers: headers
+      }.not_to change(SavedMovie, :count)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig("data","attributes","title")).to eq("Hereditary")
+    end
+
+    it "returns 404 when tmdb_id is provided but TMDB returns nil" do
+      allow(TmdbService).to receive(:movie_details).with(tmdb_id).and_return(nil)
+
+      post "/api/v1/saved_movies",
+        params: { saved_movie: { tmdb_id: tmdb_id } },
+        headers: headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body["error"]).to eq("Movie not found")
+    end
+
+    it "returns 400 when neither movie_id nor tmdb_id is provided" do
+      post "/api/v1/saved_movies",
+        params: { saved_movie: {} },
+        headers: headers
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body["error"]).to eq("movie_id or tmdb_id is required")
+    end
+  end
+
+  describe "DELETE /api/v1/saved_movies/:id (edge)" do
+    it "returns 404 if the saved movie is not found" do
+      delete "/api/v1/saved_movies/999999", headers: headers
+      expect(response).to have_http_status(:not_found)
+      expect(response.parsed_body["error"]).to eq("Saved movie not found")
+    end
+  end
 end

--- a/spec/services/open_ai_service_spec.rb
+++ b/spec/services/open_ai_service_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe OpenAiService do
+  def stub_openai(status: 200, body:)
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: status, body: body.to_json, headers: { 'Content-Type' => 'application/json' })
+  end
+
+  let(:common_params) do
+    {
+      mood: "Never trust the gas station attendant",
+      genre: "Horror",
+      decade: "1970s",
+      runtime_filter: "90–120 mins"
+    }
+  end
+
+  describe ".recommend_movies" do
+    it "returns 3 normalized items on clean JSON array" do
+      content = [
+        { "title" => "Deliverance", "release_year" => 1972 },
+        { "title" => "The Texas Chain Saw Massacre", "release_year" => 1974 },
+        { "title" => "The Hills Have Eyes", "release_year" => 1977 }
+      ]
+      stub_openai(body: {
+        choices: [{ message: { content: content.to_json } }]
+      })
+
+      result = described_class.recommend_movies(**common_params)
+      expect(result).to be_a(Hash)
+      expect(result[:items]).to eq([
+        { title: "Deliverance", release_year: 1972 },
+        { title: "The Texas Chain Saw Massacre", release_year: 1974 },
+        { title: "The Hills Have Eyes", release_year: 1977 }
+      ])
+      expect(result[:prompt]).to include('Return EXACTLY 3 items')
+      expect(result[:full_response]).to be_present
+    end
+
+    it "handles ```json fenced response" do
+      fenced = <<~TXT
+        ```json
+        [
+          {"title":"Wrong Turn","release_year":2003},
+          {"title":"Eden Lake","release_year":2008},
+          {"title":"The Ritual","release_year":2017}
+        ]
+        ```
+      TXT
+      stub_openai(body: { choices: [{ message: { content: fenced } }] })
+
+      items = described_class.recommend_movies(**common_params)[:items]
+      expect(items.map { |h| h[:title] }).to eq(["Wrong Turn", "Eden Lake", "The Ritual"])
+    end
+
+    it "extracts first JSON block from messy prose" do
+      messy = <<~TXT
+        Here are some strong picks:
+        [
+          {"title":"Green Room","release_year":2015},
+          {"title":"Calibre","release_year":2018},
+          {"title":"Backcountry","release_year":2014}
+        ]
+        Enjoy.
+      TXT
+      stub_openai(body: { choices: [{ message: { content: messy } }] })
+
+      items = described_class.recommend_movies(**common_params)[:items]
+      expect(items.map { |h| h[:title] }).to eq(["Green Room", "Calibre", "Backcountry"])
+    end
+
+    it "returns empty items on JSON parse error" do
+      stub_openai(body: { choices: [{ message: { content: "not json at all" } }] })
+
+      result = described_class.recommend_movies(**common_params)
+      expect(result[:items]).to eq([])
+    end
+
+    it "returns nil on non-success HTTP" do
+      stub_openai(status: 502, body: { error: "Bad gateway" })
+      expect(described_class.recommend_movies(**common_params)).to be_nil
+    end
+
+    it "returns nil on network error" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .to_raise(Net::ReadTimeout.new)
+      expect(described_class.recommend_movies(**common_params)).to be_nil
+    end
+  end
+
+  describe ".recommend_movie" do
+    it "returns a single title hash on success" do
+      stub_openai(body: {
+        choices: [{ message: { content: "Straw Dogs" } }]
+      })
+
+      result = described_class.recommend_movie(**common_params)
+      expect(result).to match(
+        title: "Straw Dogs",
+        full_response: a_hash_including("choices")
+      )
+    end
+
+    it "returns nil when HTTP fails" do
+      stub_openai(status: 500, body: { error: "nope" })
+      expect(described_class.recommend_movie(**common_params)).to be_nil
+    end
+  end
+
+  describe ".generate_prompt" do
+    it "includes mood/genre/decade/runtime and TMDB instruction" do
+      txt = described_class.generate_prompt(**common_params)
+      expect(txt).to include("mood:")
+      expect(txt).to include("Genre")
+      expect(txt).to include("Decade")
+      expect(txt).to include("Runtime")
+      expect(txt).to include("Return only the exact, full movie title")
+      expect(txt).to include("TMDB")
+    end
+  end
+
+  describe ".generate_prompt_multi" do
+    it "asks for exactly 3 items and raw JSON array" do
+      txt = described_class.generate_prompt_multi(**common_params)
+      expect(txt).to include('Return EXACTLY 3 items')
+      expect(txt).to include('respond ONLY with raw JSON')
+      expect(txt).to include('"title": "Exact TMDB title"')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR introduces several enhancements and refactors to improve our recommendation and saved movies functionality, as well as overall test coverage.

## Changes

- **OpenAI Service**
  - Added method to return three recommendations in a single AI response with updated prompt logic.
  - Updated `recommend_movies` method to include release year in the response.
  - Added `generate_prompt_multi` for batch recommendations.
  - Refactored `full_poster_url` helper method.
  - Created new method to search TMDB for a movie by title and year.
  - Updated `recommend_movie` method and related logic in `RecommendationsController` to align with refactored services.

- **Recommendations**
  - Updated controller to handle enriched primary recommendations so the batch includes a database ID accessible by the frontend.
  - Successfully tested updated recommendation flow in Postman.

- **Saved Movies**
  - Added idempotent save logic to `SavedMoviesController#create`.
  - Implemented dynamic movie lookup by either `movie_id` or `tmdb_id`, with fallback to fetch details from TMDB if missing locally.
  - Added edge case handling and corresponding request specs.

- **Testing**
  - Generated new service spec for `OpenAiService` with unit tests for both single and multi-movie recommendation methods.
  - Refactored request specs for saved movies to cover new edge cases and idempotent saving.
  - Increased overall test coverage to over 97%.

## Notes
- All tests are passing.
- Closes #19 